### PR TITLE
fix: host tag got overridden

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -86,21 +86,21 @@ Total number of message bytes \(including framing, such as per-Message framing a
 Total number of requests sent to Kafka brokers
 
 * Type: `Gauge`
-* Tags: `host=broker_nodes` `broker=true`
+* Tags: `broker=broker_nodes`
 
 ### `kafka_brokers_tx_bytes_total`
 
 Total number of bytes transmitted to Kafka brokers
 
 * Type: `Gauge`
-* Tags: `host=broker_nodes` `broker=true`
+* Tags: `broker=broker_nodes`
 
 ### `kafka_brokers_rtt_average_milliseconds`
 
 Broker latency / round-trip time in microseconds
 
 * Type: `Gauge`
-* Tags: `host=broker_nodes` `broker=true`
+* Tags: `broker=broker_nodes`
 
 ## Resource Usage
 

--- a/publisher/kafka.go
+++ b/publisher/kafka.go
@@ -103,9 +103,9 @@ func (pr *Kafka) ReportStats() {
 				rttValue := brokerStats["rtt"].(map[string]interface{})
 				nodeName := strings.Split(brokerStats["nodename"].(string), ":")[0]
 
-				metrics.Gauge("kafka_brokers_tx_total", brokerStats["tx"], fmt.Sprintf("host=%s,broker=true", nodeName))
-				metrics.Gauge("kafka_brokers_tx_bytes_total", brokerStats["txbytes"], fmt.Sprintf("host=%s,broker=true", nodeName))
-				metrics.Gauge("kafka_brokers_rtt_average_milliseconds", rttValue["avg"], fmt.Sprintf("host=%s,broker=true", nodeName))
+				metrics.Gauge("kafka_brokers_tx_total", brokerStats["tx"], fmt.Sprintf("broker=%s", nodeName))
+				metrics.Gauge("kafka_brokers_tx_bytes_total", brokerStats["txbytes"], fmt.Sprintf("broker=%s", nodeName))
+				metrics.Gauge("kafka_brokers_rtt_average_milliseconds", rttValue["avg"], fmt.Sprintf("broker=%s", nodeName))
 			}
 
 		default:


### PR DESCRIPTION
**BUG**
By default, Telegraf sets `host` tag in metrics that are sent to Telegraf. Few Raccoon metrics populate `host` tag for Kafka broker tag. It can cause problems for Telegraf. In our case, the metrics are detected as duplicated when Telegraf sends them to our monitoring solution.

I made changes to use `broker` as the tag name instead.