### PR TITLE
refactor: update package names

### DIFF
--- a/app/proc.go
+++ b/app/proc.go
@@ -2,7 +2,8 @@ package app
 
 import (
 	"context"
-	"raccoon/logger"
+
+	"github.com/odpf/raccoon/logger"
 )
 
 //Run the server

--- a/app/server.go
+++ b/app/server.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"raccoon/collection"
-	"raccoon/config"
-	"raccoon/services"
-	"raccoon/logger"
-	"raccoon/metrics"
-	"raccoon/publisher"
-	"raccoon/worker"
 	"runtime"
 	"syscall"
 	"time"
+
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	"github.com/odpf/raccoon/publisher"
+	"github.com/odpf/raccoon/services"
+	"github.com/odpf/raccoon/worker"
 )
 
 // StartServer starts the server

--- a/collection/collector.go
+++ b/collection/collector.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"raccoon/identification"
-	pb "raccoon/proto"
+	"github.com/odpf/raccoon/identification"
+	pb "github.com/odpf/raccoon/proto"
 )
 
 type CollectRequest struct {

--- a/config/distribution.go
+++ b/config/distribution.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"raccoon/config/util"
+	"github.com/odpf/raccoon/config/util"
 
 	"github.com/spf13/viper"
 )

--- a/config/log.go
+++ b/config/log.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"raccoon/config/util"
+	"github.com/odpf/raccoon/config/util"
 
 	"github.com/spf13/viper"
 )

--- a/config/metric.go
+++ b/config/metric.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"raccoon/config/util"
 	"time"
+
+	"github.com/odpf/raccoon/config/util"
 
 	"github.com/spf13/viper"
 )

--- a/config/publisher.go
+++ b/config/publisher.go
@@ -3,11 +3,10 @@ package config
 import (
 	"bytes"
 	"os"
-	"raccoon/config/util"
 	"strings"
 
+	"github.com/odpf/raccoon/config/util"
 	"github.com/spf13/viper"
-
 	confluent "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 

--- a/config/server.go
+++ b/config/server.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"raccoon/config/util"
 	"time"
 
+	"github.com/odpf/raccoon/config/util"
 	"github.com/spf13/viper"
 )
 

--- a/config/worker.go
+++ b/config/worker.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"raccoon/config/util"
 	"time"
 
+	"github.com/odpf/raccoon/config/util"
 	"github.com/spf13/viper"
 )
 

--- a/deserialization/proto_test.go
+++ b/deserialization/proto_test.go
@@ -1,8 +1,9 @@
 package deserialization
 
 import (
-	pb "raccoon/proto"
 	"testing"
+
+	pb "github.com/odpf/raccoon/proto"
 )
 
 func TestProtoDeserilizer_Deserialize(t *testing.T) {

--- a/docs/example/main.go
+++ b/docs/example/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"fmt"
 	"net/http"
-	pb "raccoon/proto"
 	"time"
 
 	"github.com/gorilla/websocket"
+	pb "github.com/odpf/raccoon/proto"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module raccoon
+module github.com/odpf/raccoon
 
 go 1.14
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -13,9 +13,8 @@ import (
 	"testing"
 	"time"
 
-	pb "raccoon/proto"
-
 	"github.com/gorilla/websocket"
+	pb "github.com/odpf/raccoon/proto"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"raccoon/app"
-	"raccoon/config"
-	"raccoon/logger"
-	"raccoon/metrics"
+	"github.com/odpf/raccoon/app"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
 )
 
 func main() {

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -2,9 +2,9 @@ package metrics
 
 import (
 	"fmt"
-	"raccoon/config"
-	"raccoon/logger"
 
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/logger"
 	client "gopkg.in/alexcesaro/statsd.v2"
 )
 

--- a/publisher/kafka.go
+++ b/publisher/kafka.go
@@ -3,15 +3,16 @@ package publisher
 import (
 	"encoding/json"
 	"fmt"
-	"raccoon/collection"
 
+	"github.com/odpf/raccoon/collection"
 	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+
 	// Importing librd to make it work on vendor mode
-	"raccoon/config"
-	"raccoon/logger"
-	"raccoon/metrics"
 	"strings"
 
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
 	_ "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka/librdkafka"
 )
 

--- a/publisher/kafka_test.go
+++ b/publisher/kafka_test.go
@@ -3,11 +3,11 @@ package publisher
 import (
 	"fmt"
 	"os"
-	"raccoon/collection"
-	"raccoon/logger"
-	pb "raccoon/proto"
 	"testing"
 
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/logger"
+	pb "github.com/odpf/raccoon/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"

--- a/serialization/json_test.go
+++ b/serialization/json_test.go
@@ -2,9 +2,10 @@ package serialization
 
 import (
 	"fmt"
-	pb "raccoon/proto"
 	"reflect"
 	"testing"
+
+	pb "github.com/odpf/raccoon/proto"
 )
 
 func TestJSONSerializer_Serialize(t *testing.T) {

--- a/services/grpc/handler.go
+++ b/services/grpc/handler.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"raccoon/collection"
-	"raccoon/config"
-	"raccoon/identification"
-	"raccoon/metrics"
-	pb "raccoon/proto"
 	"time"
 
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/identification"
+	"github.com/odpf/raccoon/metrics"
+	pb "github.com/odpf/raccoon/proto"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/services/grpc/handler_test.go
+++ b/services/grpc/handler_test.go
@@ -2,14 +2,14 @@ package grpc
 
 import (
 	"context"
-	"raccoon/collection"
-	"raccoon/config"
-	"raccoon/logger"
-	"raccoon/metrics"
-	pb "raccoon/proto"
 	"reflect"
 	"testing"
 
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	pb "github.com/odpf/raccoon/proto"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/services/grpc/service.go
+++ b/services/grpc/service.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"raccoon/collection"
-	"raccoon/config"
-	pb "raccoon/proto"
 
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	pb "github.com/odpf/raccoon/proto"
 	"google.golang.org/grpc"
 )
 

--- a/services/rest/handler.go
+++ b/services/rest/handler.go
@@ -5,15 +5,16 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"raccoon/collection"
-	"raccoon/config"
-	"raccoon/deserialization"
-	"raccoon/identification"
-	"raccoon/logger"
-	"raccoon/metrics"
-	pb "raccoon/proto"
-	"raccoon/serialization"
 	"time"
+
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/deserialization"
+	"github.com/odpf/raccoon/identification"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	pb "github.com/odpf/raccoon/proto"
+	"github.com/odpf/raccoon/serialization"
 )
 
 const (

--- a/services/rest/response.go
+++ b/services/rest/response.go
@@ -2,8 +2,9 @@ package rest
 
 import (
 	"io"
-	pb "raccoon/proto"
-	"raccoon/serialization"
+
+	pb "github.com/odpf/raccoon/proto"
+	"github.com/odpf/raccoon/serialization"
 )
 
 type Response struct {

--- a/services/rest/response_test.go
+++ b/services/rest/response_test.go
@@ -3,11 +3,12 @@ package rest
 import (
 	"bytes"
 	"errors"
-	pb "raccoon/proto"
-	"raccoon/serialization"
 	"reflect"
 	"testing"
 	"time"
+
+	pb "github.com/odpf/raccoon/proto"
+	"github.com/odpf/raccoon/serialization"
 )
 
 func TestResponse_SetCode(t *testing.T) {

--- a/services/rest/service.go
+++ b/services/rest/service.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"raccoon/collection"
-	"raccoon/config"
-	"raccoon/services/rest/websocket"
-	"raccoon/services/rest/websocket/connection"
-	"raccoon/metrics"
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/metrics"
+	"github.com/odpf/raccoon/services/rest/websocket"
+	"github.com/odpf/raccoon/services/rest/websocket/connection"
 )
 
 type Service struct {

--- a/services/rest/websocket/connection/conn.go
+++ b/services/rest/websocket/connection/conn.go
@@ -2,12 +2,12 @@ package connection
 
 import (
 	"fmt"
-	"raccoon/identification"
-	"raccoon/logger"
-	"raccoon/metrics"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/odpf/raccoon/identification"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
 )
 
 type Conn struct {

--- a/services/rest/websocket/connection/table.go
+++ b/services/rest/websocket/connection/table.go
@@ -2,8 +2,9 @@ package connection
 
 import (
 	"errors"
-	"raccoon/identification"
 	"sync"
+
+	"github.com/odpf/raccoon/identification"
 )
 
 var (

--- a/services/rest/websocket/connection/table_test.go
+++ b/services/rest/websocket/connection/table_test.go
@@ -1,9 +1,9 @@
 package connection
 
 import (
-	"raccoon/identification"
 	"testing"
 
+	"github.com/odpf/raccoon/identification"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/services/rest/websocket/connection/upgrader.go
+++ b/services/rest/websocket/connection/upgrader.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"raccoon/identification"
-	"raccoon/logger"
-	"raccoon/metrics"
-	pb "raccoon/proto"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/odpf/raccoon/identification"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	pb "github.com/odpf/raccoon/proto"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/services/rest/websocket/connection/upgrader_test.go
+++ b/services/rest/websocket/connection/upgrader_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"raccoon/logger"
-	"raccoon/metrics"
 	"strings"
 	"sync"
 	"testing"
@@ -13,6 +11,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/services/rest/websocket/handler.go
+++ b/services/rest/websocket/handler.go
@@ -3,18 +3,17 @@ package websocket
 import (
 	"fmt"
 	"net/http"
-	"raccoon/collection"
-	"raccoon/config"
-	"raccoon/deserialization"
-	"raccoon/logger"
-	"raccoon/metrics"
-	"raccoon/serialization"
-	"raccoon/services/rest/websocket/connection"
 	"time"
 
-	pb "raccoon/proto"
-
 	"github.com/gorilla/websocket"
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/config"
+	"github.com/odpf/raccoon/deserialization"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	pb "github.com/odpf/raccoon/proto"
+	"github.com/odpf/raccoon/serialization"
+	"github.com/odpf/raccoon/services/rest/websocket/connection"
 )
 
 type serDe struct {

--- a/services/rest/websocket/handler_test.go
+++ b/services/rest/websocket/handler_test.go
@@ -3,11 +3,6 @@ package websocket
 import (
 	"net/http"
 	"net/http/httptest"
-	"raccoon/collection"
-	"raccoon/logger"
-	"raccoon/metrics"
-	pb "raccoon/proto"
-	"raccoon/services/rest/websocket/connection"
 	"reflect"
 	"strings"
 	"testing"
@@ -15,6 +10,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	pb "github.com/odpf/raccoon/proto"
+	"github.com/odpf/raccoon/services/rest/websocket/connection"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/services/rest/websocket/pinger.go
+++ b/services/rest/websocket/pinger.go
@@ -2,11 +2,12 @@ package websocket
 
 import (
 	"fmt"
-	"raccoon/services/rest/websocket/connection"
-	"raccoon/identification"
-	"raccoon/logger"
-	"raccoon/metrics"
 	"time"
+
+	"github.com/odpf/raccoon/identification"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	"github.com/odpf/raccoon/services/rest/websocket/connection"
 )
 
 //Pinger is worker that pings the connected peers based on ping interval.

--- a/services/services.go
+++ b/services/services.go
@@ -2,12 +2,12 @@ package services
 
 import (
 	"context"
-	"raccoon/collection"
-	"raccoon/logger"
 
-	"raccoon/services/grpc"
-	"raccoon/services/pprof"
-	"raccoon/services/rest"
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/services/grpc"
+	"github.com/odpf/raccoon/services/pprof"
+	"github.com/odpf/raccoon/services/rest"
 )
 
 type bootstrapper interface {

--- a/worker/init_test.go
+++ b/worker/init_test.go
@@ -2,8 +2,9 @@ package worker
 
 import (
 	"os"
-	"raccoon/logger"
 	"testing"
+
+	"github.com/odpf/raccoon/logger"
 )
 
 type void struct{}

--- a/worker/mocks.go
+++ b/worker/mocks.go
@@ -1,10 +1,8 @@
 package worker
 
 import (
-	"raccoon/collection"
-
+	"github.com/odpf/raccoon/collection"
 	mock "github.com/stretchr/testify/mock"
-
 	kafka "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,14 +2,13 @@ package worker
 
 import (
 	"fmt"
-	"raccoon/collection"
-	"raccoon/logger"
-	"raccoon/metrics"
 	"sync"
 	"time"
 
-	"raccoon/publisher"
-
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/logger"
+	"github.com/odpf/raccoon/metrics"
+	"github.com/odpf/raccoon/publisher"
 	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -6,11 +6,9 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-
-	"raccoon/collection"
-	"raccoon/identification"
-	pb "raccoon/proto"
-
+	"github.com/odpf/raccoon/collection"
+	"github.com/odpf/raccoon/identification"
+	pb "github.com/odpf/raccoon/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
Change package names throughout Raccoon to more standard naming, which includes `directory/user`

Eg - `raccoon/config` -> `github.com/odpf/raccoon`

Signed-off-by: ramey <rameygirdhar@gmail.com>