### PR TITLE
feat: message ack sync changes improvements

### DIFF
--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -64,11 +64,11 @@ Event data loss happens in the following scenarios:
 
 ## Acknowledging events
 
-Event acknowledgements was designed to signify if the events batch is received and sent to Kafka successfully. This will enable the clients to retry on failed event delivery. Raccoon chooses when to send event acknoledgements based on the configuration parameter `EVENT_ACK`.  
+Event acknowledgements was designed to signify if the events batch is received and sent to Kafka successfully. This will enable the clients to retry on failed event delivery. Raccoon chooses when to send event acknowledgement based on the configuration parameter `EVENT_ACK`.  
 
 ### EVENT_ACK = 0
 
-Raccoon sends the acknowledgments as soon as it receives and deserializes the events successfully using the proto `SendEventRequest`. This configuration is recommended when low latency takes precedence over end to end acknoledment. The acks are sent even before it is produced to Kafka. The following picture depicts the sequence of the event ack.
+Raccoon sends the acknowledgments as soon as it receives and deserializes the events successfully using the proto `SendEventRequest`. This configuration is recommended when low latency takes precedence over end to end acknowledgement. The acks are sent even before it is produced to Kafka. The following picture depicts the sequence of the event ack.
 
 ![](/assets/raccoon_sync.png)
 

--- a/services/rest/service.go
+++ b/services/rest/service.go
@@ -26,6 +26,8 @@ func NewRestService(c collection.Collector) *Service {
 
 	go reportConnectionMetrics(*wh.Table())
 
+	go websocket.AckHandler(websocket.AckChan)
+
 	restHandler := NewHandler(c)
 	router := mux.NewRouter()
 	router.Path("/ping").HandlerFunc(pingHandler).Methods(http.MethodGet)

--- a/services/rest/websocket/ack.go
+++ b/services/rest/websocket/ack.go
@@ -1,0 +1,38 @@
+package websocket
+
+import (
+	"time"
+
+	"github.com/odpf/raccoon/metrics"
+	"github.com/odpf/raccoon/serialization"
+	"github.com/odpf/raccoon/services/rest/websocket/connection"
+)
+
+var AckChan = make(chan AckInfo)
+
+type AckInfo struct {
+	MessageType     int
+	RequestGuid     string
+	Err             error
+	Conn            connection.Conn
+	serializer      serialization.SerializeFunc
+	TimeConsumed    time.Time
+	AckTimeConsumed time.Time
+}
+
+func AckHandler(ch <-chan AckInfo) {
+	for c := range ch {
+		ackTim := time.Since(c.AckTimeConsumed)
+		metrics.Timing("ack_event_rtt_ms", ackTim.Milliseconds(), "")
+
+		tim := time.Since(c.TimeConsumed)
+		if c.Err != nil {
+			metrics.Timing("event_rtt_ms", tim.Milliseconds(), "")
+			writeFailedResponse(c.Conn, c.serializer, c.MessageType, c.RequestGuid, c.Err)
+			continue
+		}
+
+		metrics.Timing("event_rtt_ms", tim.Milliseconds(), "")
+		writeSuccessResponse(c.Conn, c.serializer, c.MessageType, c.RequestGuid)
+	}
+}

--- a/services/rest/websocket/connection/conn.go
+++ b/services/rest/websocket/connection/conn.go
@@ -30,7 +30,10 @@ func (c *Conn) Ping(writeWaitInterval time.Duration) error {
 }
 
 func (c *Conn) Close() {
-	c.conn.Close()
+	if err := c.conn.Close(); err != nil {
+		logger.Errorf("[Connection Error] %v", err)
+		metrics.Increment("conn_close_err_count", "")
+	}
 	c.calculateSessionTime()
 	c.closeHook(*c)
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -46,6 +46,9 @@ func (w *Pool) StartWorkers() {
 
 				err := w.kafkaProducer.ProduceBulk(request.GetEvents(), request.ConnectionIdentifier.Group, deliveryChan)
 
+				produceTime := time.Since(batchReadTime)
+				metrics.Timing("kafka_producebulk_tt_ms", produceTime.Milliseconds(), "")
+
 				if request.AckFunc != nil {
 					request.AckFunc(err)
 				}
@@ -75,7 +78,7 @@ func (w *Pool) StartWorkers() {
 }
 
 // FlushWithTimeOut waits for the workers to complete the pending the messages
-//to be flushed to the publisher within a timeout.
+// to be flushed to the publisher within a timeout.
 // Returns true if waiting timed out, meaning not all the events could be processed before this timeout.
 func (w *Pool) FlushWithTimeOut(timeout time.Duration) bool {
 	c := make(chan struct{})


### PR DESCRIPTION
Removed the connection block on reading the messages for open active connection
Implemented the single go-routine for the sync ack response reporting
Moved the ack changes to the new file ack.go
Added couple of new metrics to check the tt for kafka batch publish and for the ack response. 
#42 

Perf Results: `Ack Channel`
go-routine per connection (blue) vs single go-routine for all connections (yellow)
![image](https://user-images.githubusercontent.com/5475978/188137722-74770c91-6258-414c-b7d0-88e42c229e29.png)
