### PR TITLE
JS Client: Add websocket support

### DIFF
--- a/clients/js/lib/client.js
+++ b/clients/js/lib/client.js
@@ -55,7 +55,7 @@ class RaccoonClient extends EventEmitter {
         this.timeout = options.timeout || 1000;
         this.uuidGenerator = () => uuidv4();
         this.protocol = options.protocol || 'rest';
-        
+
         if (this.protocol === 'rest') {
             this.httpClient = axios.create();
         } else if (this.protocol === 'ws') {
@@ -131,13 +131,12 @@ class RaccoonClient extends EventEmitter {
             );
 
             this.logger.info(`ended request, url: ${this.url}, req-id: ${requestId}`);
-            
 
             if (this.protocol !== 'rest') {
                 return {
-                    reqId: requestId,
+                    reqId: requestId
                 };
-            } 
+            }
 
             const sendEventResponse = this.marshaller.unmarshal(
                 response,
@@ -148,7 +147,6 @@ class RaccoonClient extends EventEmitter {
                 response: sendEventResponse.toJSON(),
                 error: null
             };
-
         } catch (error) {
             this.logger.error(`error, url: ${this.url}, req-id: ${requestId}, ${error}`);
             throw new Error(`req-id: ${requestId}, error: ${error}`);

--- a/clients/js/lib/client.js
+++ b/clients/js/lib/client.js
@@ -10,6 +10,7 @@ import createProtoMarshaller from './wire/proto_wire.js';
 import createJsonMarshaller from './wire/json_wire.js';
 import { raystack, google } from '../protos/proton_compiled.js';
 import EventEmitter from 'events';
+import WebSocket from 'ws';
 
 const NANOSECONDS_PER_MILLISECOND = 1e6;
 
@@ -65,7 +66,6 @@ class RaccoonClient extends EventEmitter {
     }
 
     initializeWebSocket() {
-        const WebSocket = require('ws');
         this.wsClient = new WebSocket(this.url);
         this.wsClient.on('open', () => {
             this.logger.info('WebSocket connection established');
@@ -75,8 +75,9 @@ class RaccoonClient extends EventEmitter {
         });
         this.wsClient.on('message', (data) => {
             try {
+                const response = JSON.parse(data);
                 const sendEventResponse = this.marshaller.unmarshal(
-                    data,
+                    response,
                     raystack.raccoon.v1beta1.SendEventResponse
                 );
                 this.emit('ack', sendEventResponse.toJSON());

--- a/clients/js/lib/client.js
+++ b/clients/js/lib/client.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
+import EventEmitter from 'events';
+import WebSocket from 'ws';
 
 import createJsonSerializer from './serializer/json_serializer.js';
 import createProtobufSerializer from './serializer/proto_serializer.js';
@@ -9,8 +11,6 @@ import WireType from './types/wire_type.js';
 import createProtoMarshaller from './wire/proto_wire.js';
 import createJsonMarshaller from './wire/json_wire.js';
 import { raystack, google } from '../protos/proton_compiled.js';
-import EventEmitter from 'events';
-import WebSocket from 'ws';
 
 const NANOSECONDS_PER_MILLISECOND = 1e6;
 

--- a/clients/js/main.js
+++ b/clients/js/main.js
@@ -1,3 +1,3 @@
-import { RaccoonClient, SerializationType, WireType } from './lib/rest.js';
+import { RaccoonClient, SerializationType, WireType } from './lib/client.js';
 
 export { RaccoonClient, SerializationType, WireType };

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@raystack/raccoon",
-  "version": "0.1.0-rc2",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raystack/raccoon",
-      "version": "0.1.0-rc2",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",
         "protobufjs": "^7.2.4",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "eslint": "^8.47.0",
@@ -5761,6 +5762,26 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "axios": "^1.4.0",
     "protobufjs": "^7.2.4",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "eslint": "^8.47.0",

--- a/clients/js/test/rest.test.js
+++ b/clients/js/test/rest.test.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 import { jest } from '@jest/globals';
-import { RaccoonClient, SerializationType, WireType } from '../lib/rest.js';
+import { RaccoonClient, SerializationType, WireType } from '../lib/client.js';
 import { raystack, google } from '../protos/proton_compiled.js';
 
 const mockHTTPClient = {

--- a/docs/docs/clients/javascript.md
+++ b/docs/docs/clients/javascript.md
@@ -4,8 +4,7 @@
 Make sure that Nodejs >= `20.0` is installed on your system. See [installation instructions](https://nodejs.org/en/download/package-manager) on Nodejs's website for more info.
 
 ## Installation
-Install Raccoon's Javascript client using [npm](https://docs.npmjs.com/cli/v10/commands/npm)
-```javascript
+Install Raccoon's Javascript client using [npm](https://docs.npmjs.com/cli/v10/commands/npm)```javascript
 $ npm install --save @raystack/raccoon
 ```
 ## Usage
@@ -64,7 +63,8 @@ To create the client, use `new RaccoonClient(options)`. `options` is javascript 
 | retryMax | The maximum number of retry attempts for failed requests (default: `3`) |
 | retryWait | The time in milliseconds to wait between retry attempts (default: `1000`)| 
 | timeout | The timeout in milliseconds (default: `1000`)|
-| logger | Logger object for logging (default: `global.console`)
+| logger | Logger object for logging (default: `global.console`)|
+| protocol | The protocol to use, either 'rest' or 'ws' (default: 'rest') |
 
 #### Publishing events
 To publish events, create an array of objects and pass it to `RaccoonClient#send()`. The return value is a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
@@ -92,6 +92,29 @@ The following table lists which serializer to use for a given payload type.
 | Protobuf | `SerializationType.PROTOBUF`|
 
 Once a client is constructed with a specific kind of serializer, you may only pass it events of that specific type. In particular, for `JSON` serialiser the event data must be a javascript object. While for `PROTOBUF` serialiser the event data must be a protobuf message.
+
+#### Working with WebSocket
+
+When using the websocket protocol, the response from the server is not returned immediately. Instead, the client is notified of the event's status via an `ack` event. You can subscribe to the `ack` event with `client.on('ack', callback)`. You can select the protocol by setting the `protocol` option in the client constructor. Here's an example:
+
+```js
+const client = new RaccoonClient({
+    protocol: 'ws',
+    url: 'ws://localhost:8080/api/v1/events',
+    serializationType: SerializationType.JSON,
+    wireType: WireType.JSON,
+});
+
+client.on('ack', (event) => {
+    console.log('Response received:', event); // event is of type SendEventResponse
+});
+
+client.send(events)
+    .then(result => console.log('Request ID:', result.reqID))
+    .catch(err => console.error(err))
+```
+
+
 
 ## Examples
 You can find examples of client usage [here](https://github.com/raystack/raccoon/tree/main/clients/js/examples)


### PR DESCRIPTION
* Adds support for Websocket protocol in Javascript Client.
* User can pass in `options.protocol` as `ws` to request websocket protocol. (defaults to `rest`)
* Client is now a subclass of `EventEmitter`. When `ws` protocol is enabled, the client emits an `ack` event for every server response.
* Updated user documentation to add details about Websocket support
